### PR TITLE
Adding note to env secret yaml example

### DIFF
--- a/articles/aks/csi-secrets-store-driver.md
+++ b/articles/aks/csi-secrets-store-driver.md
@@ -234,6 +234,8 @@ After you've created the Kubernetes secret, you can reference it by setting an e
 > [!NOTE]
 > The example here is incomplete. You'll need to modify it to support the Azure key vault identity access that you've chosen.
 
+> [!NOTE]
+> The example here demonstrates access to a secret through env and through volume/volumeMount. This is for illustrative purposes. These two methods can exist independently from the other. 
 ```yml
 kind: Pod
 apiVersion: v1


### PR DESCRIPTION
This yaml example includes both an env variable referencing a secret and a separate volume/volumeMount for the same secret. Adding in a note to assert that this is for illustrative purposes as customer might think that these two methods are dependent of one another - this is not the case - these methods can be used interpedently of the other for the purpose of getting the same secret.